### PR TITLE
Flipping out-of-bounds indicator to point towards the player

### DIFF
--- a/Assets/Player/PlayerIndicator.cs
+++ b/Assets/Player/PlayerIndicator.cs
@@ -43,9 +43,8 @@ public class PlayerIndicator : MonoBehaviour
 
         if (!offscreen) return;
 
-        // if ball is out of bounds on the left side, flip the icon to the left (y axis)
-        spriteRenderer.flipX = viewportPosition.x < 0.5f;
-        spriteRenderer.flipY = viewportPosition.y < 0.5f;
+        spriteRenderer.flipX = viewportPosition.x < 0.5f; // if the player ball is out of bounds on the left side, flip the icon to the left (flip x values)
+        spriteRenderer.flipY = viewportPosition.y < 0.5f; // if the player ball is out of bounds at the bottom, flip the icon upside down (flip y values)
 
         viewportPosition.x = Mathf.Clamp(viewportPosition.x, EDGE_PADDING, 1f - EDGE_PADDING);
         viewportPosition.y = Mathf.Clamp(viewportPosition.y, EDGE_PADDING, 1f - EDGE_PADDING);


### PR DESCRIPTION
The out-of-bounds indicator now actually points towards the position of the player depending on which coordinate is out of bounds and where.