### PR TITLE
Fix blackhole windmill interaction

### DIFF
--- a/Assets/World/GravityField/GravityField.cs
+++ b/Assets/World/GravityField/GravityField.cs
@@ -33,6 +33,8 @@ public class GravityField : MonoBehaviour
     {
         var dir = transform.position - collision.transform.position;
         var gravity = dir.normalized * gravityFactor / dir.sqrMagnitude;
-        collision.attachedRigidbody.AddForce(gravity, ForceMode2D.Force);
+        Rigidbody2D attachedRigidbody = collision.attachedRigidbody;
+        if (attachedRigidbody.bodyType == RigidbodyType2D.Dynamic)
+            attachedRigidbody.AddForce(gravity, ForceMode2D.Force);
     }
 }


### PR DESCRIPTION
- closes #111 
- gravity force is only applied to dynamic rigidbodies not kinematic ones, since this leads to game crashes (windmill) 
